### PR TITLE
New flags for default placement.

### DIFF
--- a/src/threading/lpel/lpelmod/assign.h
+++ b/src/threading/lpel/lpelmod/assign.h
@@ -1,6 +1,15 @@
 #ifndef _ASSIGN_H_
 #define _ASSIGN_H_
 
+typedef enum  {
+    ASSIGN_ONE_THREAD, /* all on one worker */
+    ASSIGN_ROUND_ROBIN_SHARED, /* round-robin on all entities, boxes switch to next worker */
+    ASSIGN_ROUND_ROBIN_PER_ENTITY, /* round-robin per box + global round-robin for other entities */
+    ASSIGN_D_SNET_EXPLICIT, /* explicit placement operator in D-SNET */
+} default_task_assignment_t;
+
+extern default_task_assignment_t default_placement;
+
 void SNetAssignInit(int lpel_num_workers);
 void SNetAssignCleanup( void);
 int SNetAssignTask(int is_box, const char *boxname);


### PR DESCRIPTION
This patch introduces support for the following command-line flag:

 -dp <PLACEMENT>

This determines the default placement for tasks in worker-based
back-ends (eg LPEL or d-snet).  <PLACEMENT> can be either:
- "single"": all tasks are created on worker 0.
- "shared-rr": all tasks are distributed round-robin, regardless of
  type.
- "entity-rr": each entity has its own round-robin counter,
  and control tasks share a separate round-robin counter.
- "dsnet": use explicit distributed S-NET placement.
  (same as argument -dloc already available)
