### PR TITLE
trivial bug fix: wrong variable assignment

### DIFF
--- a/src/threading/lpel/lpelif/glue_decen.c
+++ b/src/threading/lpel/lpelif/glue_decen.c
@@ -202,7 +202,7 @@ int SNetThreadingSpawn(snet_entity_t *ent)
 
 	if ( type != ENTITY_other) {
 		if (sosi_placement && (strnstr(name, SNET_SOURCE_PREFIX, l1) || strnstr(name, SNET_SINK_PREFIX, l2))) {
-			location = LPEL_MAP_OTHERS;		// sosi placemnet and entity is source/sink
+			worker = LPEL_MAP_OTHERS;		// sosi placemnet and entity is source/sink
 		} else if (dloc_placement) {
 			assert(location != -1);
 			worker = location % num_workers;


### PR DESCRIPTION
- worker is the worker_id where task is run (-1 indicates wrapper)
- location is the user-desired location of the task
